### PR TITLE
Make FHIR Client Socket Timeout Configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ federated search deployment.
 
 ## Configuration
 
+* `APP_STORE_SOCKETTIMEOUT` - set the socket timeout as number of milliseconds for REST requests
+  towards the FHIR server. Defaults to 60000.
+
 ### Proxy
 
 If a proxy is needed to access the Searchbroker, please use the following Java properties to

--- a/src/main/java/de/samply/dktk/fedsearch/share/DktkFedSearchApplication.java
+++ b/src/main/java/de/samply/dktk/fedsearch/share/DktkFedSearchApplication.java
@@ -41,6 +41,9 @@ public class DktkFedSearchApplication {
   @Value("${app.store.baseUrl}")
   private String storeBaseUrl;
 
+  @Value("${app.store.socketTimeout}")
+  private int storeSocketTimeout;
+
   public static void main(String... args) {
     SpringApplication.run(DktkFedSearchApplication.class, args);
   }
@@ -102,6 +105,7 @@ public class DktkFedSearchApplication {
    */
   @Bean
   public IGenericClient storeClient(FhirContext context) {
+    context.getRestfulClientFactory().setSocketTimeout(storeSocketTimeout);
     var client = context.newRestfulGenericClient(storeBaseUrl);
     client.setFormatParamStyle(RequestFormatParamStyleEnum.NONE);
     return client;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,6 +5,8 @@ app:
     mail: foo
   store:
     baseUrl: http://localhost:8100/fhir
+    # increase this depending on the longest running CQL queries
+    socketTimeout: 60000
 spring:
   datasource:
     url: jdbc:postgresql://db:5432/postgres

--- a/src/test/java/de/samply/dktk/fedsearch/share/TestUtil.java
+++ b/src/test/java/de/samply/dktk/fedsearch/share/TestUtil.java
@@ -9,6 +9,7 @@ import ca.uhn.fhir.context.FhirContext;
 import de.samply.dktk.fedsearch.share.broker.model.Reply;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Objects;
 import javax.sql.DataSource;
 import org.hl7.fhir.r4.model.Bundle;
 import org.springframework.boot.jdbc.DataSourceBuilder;
@@ -97,5 +98,9 @@ public class TestUtil {
         .flatMap(s -> fhirParser.parseResource(Bundle.class, s))
         .map(fhirClient::transact)
         .orElseThrow(Exception::new);
+  }
+
+  static String getPath(String name) {
+    return Objects.requireNonNull(TestUtil.class.getResource(name)).getPath();
   }
 }

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,3 +1,6 @@
+app:
+  store:
+    socketTimeout: 60000
 spring:
   datasource:
     driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver

--- a/src/test/resources/de/samply/dktk/fedsearch/share/slow-query-nginx.conf
+++ b/src/test/resources/de/samply/dktk/fedsearch/share/slow-query-nginx.conf
@@ -1,0 +1,13 @@
+limit_req_zone $binary_remote_addr zone=mylimit:1m rate=2r/m;
+
+server {
+    listen              8090;
+
+    location / {
+      limit_req zone=mylimit burst=20;
+
+      proxy_pass http://store:8080;
+      proxy_set_header X-Forwarded-Proto http;
+      proxy_set_header X-Forwarded-Host  $http_host;
+    }
+}


### PR DESCRIPTION
CQl queries are evaluated using synchronous HTTP requests. The HAPI FHIR client has a default socket timeout of 10 seconds. This will be not sufficient for longer running queries. I added the Spring config option `app.store.socketTimeout` in order to be able to increase the timeout with a default of 60 seconds.

I added the integration test DktkFedSearchApplicationSlowQueryTest which uses an nginx container to slow down requests to 2 each minute, so that each request to Blaze takes 30 seconds.